### PR TITLE
chore: add Swagger/OpenAPI config and Dockerfile for user-service

### DIFF
--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage with Maven 3.9.9 and Java 17
+FROM maven:3.9.9-openjdk-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package -DskipTests
+
+# Run stage
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY --from=build /app/target/user-service-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java","-jar","app.jar"]

--- a/user-service/README.md
+++ b/user-service/README.md
@@ -1,0 +1,12 @@
+## User Service
+
+### Running Locally
+
+- Start with `mvn spring-boot:run` (port 8081)
+- Swagger UI: `http://localhost:8081/swagger-ui.html`
+
+### Docker
+
+```bash
+docker build -t yourrepo/user-service:latest .
+docker run -p 8081:8081 yourrepo/user-service:latest

--- a/user-service/src/main/java/com/wise/user/config/OpenApiConfig.java
+++ b/user-service/src/main/java/com/wise/user/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.wise.user.config;
+
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI userServiceOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("User Service API")
+                        .version("v1")
+                        .description("APIs for user management"));
+    }
+}

--- a/user-service/src/main/java/com/wise/user/controller/UserController.java
+++ b/user-service/src/main/java/com/wise/user/controller/UserController.java
@@ -1,3 +1,10 @@
+package com.wise.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 @RestController
 @RequestMapping("/api/v1/users")
 public class UserController {

--- a/user-service/target/classes/application.yml
+++ b/user-service/target/classes/application.yml
@@ -1,0 +1,6 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: user-service


### PR DESCRIPTION
This PR adds:
- OpenApiConfig for Swagger UI at `/swagger-ui.html`
- Dockerfile to build and run the user-service container
- README updates with Docker and Swagger instructions
