### PR TITLE
test: add health-check unit test for UserController

### DIFF
--- a/user-service/src/test/java/com/wise/user/controller/UserControllerTest.java
+++ b/user-service/src/test/java/com/wise/user/controller/UserControllerTest.java
@@ -1,0 +1,26 @@
+package com.wise.user.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("GET /api/v1/users/health → 200 OK, “User service is up!”")
+    void healthCheck_ReturnsUpMessage() throws Exception {
+        mockMvc.perform(get("/api/v1/users/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("User service is up and running!"));
+    }
+}


### PR DESCRIPTION
Adds a WebMvcTest for `UserController` to verify the /api/v1/users/health endpoint 
returns 200 OK with the expected message.

![Screenshot 2025-05-24 at 14 39 11](https://github.com/user-attachments/assets/47f34310-fa91-4219-b24a-fda85ef6c9be)
